### PR TITLE
Update dthmm.pyx and remove np.int since it is deprecated

### DIFF
--- a/hmms/dthmm.pyx
+++ b/hmms/dthmm.pyx
@@ -259,7 +259,7 @@ cdef class DtHMM:
         size = e_seq.shape[0]
         states_num = self._loga.shape[0]
         cdef numpy.ndarray[float_t, ndim=2] delta = numpy.empty( (size,states_num), dtype=numpy.float64 ) #numpy.zeros( (size, states_num ))
-        cdef numpy.ndarray[int_t, ndim=2] psi = numpy.empty( (size,states_num), dtype=numpy.int ) #numpy.zeros( (size, states_num ))
+        cdef numpy.ndarray[int_t, ndim=2] psi = numpy.empty( (size,states_num), dtype=int ) #numpy.zeros( (size, states_num ))
 
         delta[0,:] = logpi + logb[:, int(e_seq[0]) ]
         psi[0,:] = 0
@@ -285,7 +285,7 @@ cdef class DtHMM:
                 max_p = delta[-1,s]
                 p = s
 
-        cdef numpy.ndarray[int_t, ndim=1] path = numpy.full( size, 0, dtype=numpy.int )
+        cdef numpy.ndarray[int_t, ndim=1] path = numpy.full( size, 0, dtype=int )
 
         for i in range(size-1,-1,-1):
             path[i] = p


### PR DESCRIPTION
To prevent AttributeError: module 'numpy' has no attribute 'int', replace numpy.int with int